### PR TITLE
Configuration option for publishing mqtt messages with retain flag set

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -21,3 +21,5 @@ mqtt:
         password: 'mqtt_password'
     # Prefix to mqtt topic
     topicPrefix: 'knx'
+    # Set retain flag on messages
+    retain: false

--- a/src/config.js
+++ b/src/config.js
@@ -18,7 +18,8 @@ exports.parse = function () {
             },
             mqtt: {
                 url: 'mqtt://localhost',
-                topicPrefix: 'knx'
+                topicPrefix: 'knx',
+                retain: false
             }
         }
     }

--- a/src/knx-mqtt.js
+++ b/src/knx-mqtt.js
@@ -115,7 +115,9 @@ let onKnxEvent = function (evt, dst, value, gad) {
       new Date().toISOString().replace(/T/, ' ').replace(/\..+/, ''),
       evt, dst, mqttMessage);
 
-    mqttClient.publish(topicPrefix + dst, mqttMessage);
+    mqttClient.publish(topicPrefix + dst, mqttMessage, {
+        retain: config.mqtt.retain || false
+    });
 }
 
 let knxConnection = knx.Connection(Object.assign({


### PR DESCRIPTION
Sometimes it is helpful that newly connecting MQTT clients are informed about the last state of a device (window/door contacts, switches). To achieve this, you usually set the retain flag when publishing messages.
That's why I've added a configuration option that allows one to activate this behaviour.