### PR TITLE
Bugfix for possible KNX message multiplication (#6)

### DIFF
--- a/src/knx-mqtt.js
+++ b/src/knx-mqtt.js
@@ -126,6 +126,12 @@ let knxConnection = knx.Connection(Object.assign({
        logger.info('KNX connected');
         for (let key in groupAddresses) {
            if (groupAddresses.hasOwnProperty(key)) {
+               if (groupAddresses[key].endpoint) {
+                 // We already assigned an endpoint previously and there is no need to do it again here.
+                 // This will avoid a possible duplication of messages caused by multiple bound event handles for the same group address.
+                 // See https://github.com/pakerfeldt/knx-mqtt-bridge/issues/6 for further details why we really should break here.
+                 continue;
+               }
                let endpoint = new knx.Datapoint({ga: key, dpt: groupAddresses[key].dpt}, knxConnection);
                groupAddresses[key].endpoint = endpoint;
                groupAddresses[key].unit = endpoint.dpt.subtype !== undefined ? endpoint.dpt.subtype.unit || '' : '';


### PR DESCRIPTION
This is a fix for bug #6 , which may have caused the same KNX messages to be sent multiple times via MQTT.

The reason for this was the multiple registration of event handlers for the same group address caused by connection failures to the IP gateway.

Testing is straight forward because you just have to temporarily disable the network connection and see what's appearing on the MQTT topics with and without applying this patch after the connection to the KNX gateway has been re-established.