### PR TITLE
Read mqtt.options.key/cert/ca from files

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -5,7 +5,13 @@ exports.parse = function () {
     const file = process.env.KNX_MQTT_CONFIG || 'config.yaml';
     if (fs.existsSync(file)) {
         try {
-          return yaml.safeLoad(fs.readFileSync(file, 'utf8'));
+          let config =  yaml.safeLoad(fs.readFileSync(file, 'utf8'));
+          
+          if (config.mqtt.options.key) config.mqtt.options.key = fs.readFileSync( config.mqtt.options.key );
+          if (config.mqtt.options.cert) config.mqtt.options.cert = fs.readFileSync( config.mqtt.options.cert );
+          if (config.mqtt.options.ca) config.mqtt.options.ca = fs.readFileSync( config.mqtt.options.ca );
+          
+          return config
         } catch (e) {
           console.log(e);
           process.exit();


### PR DESCRIPTION
mqtt library requires these parameters to contain the actually content, not file paths.